### PR TITLE
Add workflow for filtering closed pull request events on main branch

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -36,6 +36,7 @@ jobs:
               path: app/build
     deploy:
         runs-on: ubuntu-latest
+        needs: test-build
         steps:
             - name: Download build artifact
               uses: actions/download-artifact@v3

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,0 +1,46 @@
+name: Artifacts
+
+on:
+    workflow_dispatch:
+
+jobs:
+    test-build:
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                working-directory: app
+        steps:
+          - name: Checkout code
+            uses: actions/checkout@v4
+          - name: Setup Node.js
+            uses: actions/setup-node@v3
+            with:
+                node-version: '23.x'
+          - name: Download dependencies
+            uses: actions/cache@v3
+            id: cache
+            with:
+                path: app/node_modules
+                key: deps-node-moduels-${{ hashFiles('app/package-lock.json') }}
+          - name: Install dependencies
+            if: steps.cache.outputs.cache-hit != 'true'
+            run: npm ci
+          - name: Unit tests
+            run: npm run test
+          - name: Build code
+            run: npm run build
+          - name: Upload build files
+            uses: actions/upload-artifact@v3
+            with:
+              name: app
+              path: app/build
+    deploy:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Download build artifact
+              uses: actions/download-artifact@v3
+              with:
+                name: app
+                path: build
+            - name: Show folder structure
+              run: ls -R

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,3 +1,16 @@
+# This workflow is triggered manually and builds the app, runs tests, and uploads artifacts.
+# It also downloads the build artifact for further use in the deployment jobs.
+# The workflow uses caching to speed up the installation of dependencies.
+# The workflow is set to run on the latest version of Ubuntu.
+# The workflow uses Node.js version 23.x for the build process.
+# The workflow uses the actions/checkout, actions/setup-node, actions/cache, actions/upload-artifact, and actions/download-artifact actions.
+# The workflow uses the actions/upload-artifact action to upload test coverage reports and build files.
+# The workflow uses the actions/download-artifact action to download the build artifact for deployment.
+# The workflow uses the actions/cache action to cache the node_modules directory to speed up the installation of dependencies.
+# The workflow uses the actions/setup-node action to set up Node.js for the build process.
+# The workflow uses the actions/checkout action to check out the code from the repository.
+# The workflow uses the actions/upload-artifact action to upload the test coverage reports and build files as artifacts.
+
 name: Artifacts
 
 on:

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,56 +1,56 @@
 name: Artifacts
 
 on:
-    workflow_dispatch:
+  workflow_dispatch:
 
 env:
-    build-artifact-key: app-${{ github.sha }}
-    test-coverage-key: test-coverage-${{ github.sha }}
+  build-artifact-key: app-${{ github.sha }}
+  test-coverage-key: test-coverage-${{ github.sha }}
 
 jobs:
     test-build:
-        runs-on: ubuntu-latest
-        defaults:
-            run:
-                working-directory: app
-        steps:
-          - name: Checkout code
-            uses: actions/checkout@v4
-          - name: Setup Node.js
-            uses: actions/setup-node@v3
-            with:
-                node-version: '23.x'
-          - name: Download dependencies
-            uses: actions/cache@v3
-            id: cache
-            with:
-                path: app/node_modules
-                key: deps-node-moduels-${{ hashFiles('app/package-lock.json') }}
-          - name: Install dependencies
-            if: steps.cache.outputs.cache-hit != 'true'
-            run: npm ci
-          - name: Unit tests
-            run: npm run test -- --coverage
-          - name: Upload test results
-            uses: actions/upload-artifact@v3
-            with:
-                name: ${{ env.test-coverage-key }}
-                path: app/coverage
-          - name: Build code
-            run: npm run build
-          - name: Upload build files
-            uses: actions/upload-artifact@v4
-            with:
-              name: ${{ env.build-artifact-key }}
-              path: app/build
+      runs-on: ubuntu-latest
+      defaults:
+        run:
+          working-directory: app
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v4
+        - name: Setup Node
+          uses: actions/setup-node@v4
+          with:
+            node-version: '23.x'
+        - name: Download cached dependencies
+          uses: actions/cache@v3
+          id: cache
+          with:
+            path: app/node_modules
+            key: deps-node-modules-${{ hashFiles('app/package-lock.json') }}
+        - name: Install dependencies
+          if: steps.cache.outputs.cache-hit != 'true'
+          run: npm ci
+        - name: Unit tests
+          run: npm run test -- --coverage
+        - name: Upload test results
+          uses: actions/upload-artifact@v4
+          with:
+            name: ${{ env.test-coverage-key }}
+            path: app/coverage
+        - name: Build code
+          run: npm run build
+        - name: Upload build files
+          uses: actions/upload-artifact@v4
+          with:
+            name: ${{ env.build-artifact-key }}
+            path: app/build
     deploy:
-        runs-on: ubuntu-latest
-        needs: test-build
-        steps:
-            - name: Download build artifact
-              uses: actions/download-artifact@v4
-              with:
-                name: ${{ env.build-artifact-key }}
-                path: build
-            - name: Show folder structure
-              run: ls -R
+      runs-on: ubuntu-latest
+      needs: test-build
+      steps:
+        - name: Download build artifact
+          uses: actions/download-artifact@v4
+          with:
+            name: ${{ env.build-artifact-key }}
+            path: build
+        - name: Show folder structure
+          run: ls -R

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -3,6 +3,10 @@ name: Artifacts
 on:
     workflow_dispatch:
 
+env:
+    build-artifact-key: app-${{ github.sha }}
+    test-coverage-key: test-coverage-${{ github.sha }}
+
 jobs:
     test-build:
         runs-on: ubuntu-latest
@@ -26,22 +30,27 @@ jobs:
             if: steps.cache.outputs.cache-hit != 'true'
             run: npm ci
           - name: Unit tests
-            run: npm run test
+            run: npm run test -- --coverage
+          - name: Upload test results
+            uses: actions/upload-artifact@v3
+            with:
+                name: ${{ env.test-coverage-key }}
+                path: app/coverage
           - name: Build code
             run: npm run build
           - name: Upload build files
-            uses: actions/upload-artifact@v3
+            uses: actions/upload-artifact@v4
             with:
-              name: app
+              name: ${{ env.build-artifact-key }}
               path: app/build
     deploy:
         runs-on: ubuntu-latest
         needs: test-build
         steps:
             - name: Download build artifact
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
-                name: app
+                name: ${{ env.build-artifact-key }}
                 path: build
             - name: Show folder structure
               run: ls -R

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -28,8 +28,16 @@ jobs:
             - name: Setuup Node
               uses: actions/setup-node@v3
               with:
-                node-version: ${{ inputs.node-version }}            
+                node-version: ${{ inputs.node-version }}     
+            - name: Download cached dependencies
+              uses: actions/cache@v3
+              if: ${{ inputs.use-cache }}
+              id: cache
+              with:
+                path: app/node_modules
+                key: deps-node-modules-${{ hashFiles('app/package-lock.json') }}     
             - name: Install dependencies
+              if: steps.cache.outputs.cache-hit != 'true'
               run: npm ci
             - name: Testing
               run: npm run test

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -1,3 +1,20 @@
+# This workflow demonstrates how to use caching in GitHub Actions
+# to speed up the installation of dependencies and build process.
+# It uses the actions/cache action to cache the node_modules directory
+# and the package-lock.json file.
+# The workflow is triggered manually with the option to use cache
+# and to specify the Node.js version.
+# The workflow consists of three jobs:
+    # 1. install-deps: Installs dependencies and caches them
+    # 2. lint-test: Runs linting and testing
+    # 3. build: Builds the application
+    # The install-deps job is a prerequisite for the other two jobs.
+    # The lint-test job runs linting and testing, while the build job builds the application.
+    # The caching mechanism is used to speed up the installation of dependencies
+    # and the build process by caching the node_modules directory.
+# The workflow is designed to be reusable and can be triggered manually
+# with the option to use cache and to specify the Node.js version.
+
 name: Caching
 
 on:

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -6,7 +6,15 @@ on:
             use-cache:
                 description: 'Whether to execute the cache step'
                 type: boolean
-                default: false
+                default: true
+            node-version:
+                description: 'Node version to use'
+                type: choice
+                options:
+                    - '18.x'
+                    - '20.x'
+                    - '23.x'
+                default: '23.x'
 
 jobs:
     build:
@@ -20,7 +28,7 @@ jobs:
             - name: Setuup Node
               uses: actions/setup-node@v3
               with:
-                node-version: '23.x'
+                node-version: ${{ inputs.node-version }}            
             - name: Install dependencies
               run: npm ci
             - name: Testing

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -17,8 +17,60 @@ on:
                 default: '23.x'
 
 jobs:
+    install-deps:
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                working-directory: app
+        outputs:
+            deps-cache-key: ${{ steps.cache-key.outputs.CACHE_KEY }}
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ inputs.node-version }}
+            - name: Calculate cache key
+              id: cache-key
+              run: |
+                  echo "CACHE_KEY=deps-node-modules-${{ hashFiles('app/package-lock.json') }}" >> "$GITHUB_OUTPUT"
+            - name: Download cached dependencies
+              uses: actions/cache@v3
+              if: ${{ inputs.use-cache }}
+              id: cache
+              with:
+                  path: app/node_modules
+                  key: ${{ steps.cache-key.outputs.CACHE_KEY }}
+            - name: Install dependencies
+              if: steps.cache.outputs.cache-hit != 'true'
+              run: npm ci
+    lint-test:
+            runs-on: ubuntu-latest
+            needs: install-deps
+            defaults:
+                run:
+                    working-directory: app
+            steps:
+                - name: Checkout code
+                  uses: actions/checkout@v4
+                - name: Setup Node
+                  uses: actions/setup-node@v4
+                  with:
+                      node-version: ${{ inputs.node-version }}
+                - name: Download cached dependencies
+                  uses: actions/cache@v3
+                  id: cache
+                  with:
+                      path: app/node_modules
+                      key: ${{ needs.install-deps.outputs.deps-cache-key }}
+                - name: Testing
+                  run: npm run test
+                - name: Linting
+                  run: echo "Linting…"
     build:
         runs-on: ubuntu-latest
+        needs: install-deps
         defaults:
             run:
                 working-directory: app
@@ -35,13 +87,18 @@ jobs:
               id: cache
               with:
                 path: app/node_modules
-                key: deps-node-modules-${{ hashFiles('app/package-lock.json') }}     
-            - name: Install dependencies
-              if: steps.cache.outputs.cache-hit != 'true'
-              run: npm ci
-            - name: Testing
-              run: npm run test
+                key: deps-node-modules-${{ hashFiles('app/package-lock.json') }}
             - name: Building
               run: npm run build
-            - name: Deploying to nonprod
-              run: echo "Deploying to nonprod"
+
+            
+            #- name: Install dependencies
+             # if: steps.cache.outputs.cache-hit != 'true'
+              #run: npm ci
+            #- name: Testing
+             # run: npm run test
+            #- name: Building
+             # run: npm run build
+            #- name: Deploying to nonprod
+             # run: echo "Deploying to nonprod"
+              

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -1,0 +1,31 @@
+name: Caching
+
+on:
+    workflow_dispatch:
+        inputs:
+            use-cache:
+                description: 'Whether to execute the cache step'
+                type: boolean
+                default: false
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                working-directory: app
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+            - name: Setuup Node
+              uses: actions/setup-node@v3
+              with:
+                node-version: '23.x'
+            - name: Install dependencies
+              run: npm ci
+            - name: Testing
+              run: npm run test
+            - name: Building
+              run: npm run build
+            - name: Deploying to nonprod
+              run: echo "Deploying to nonprod"

--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -1,8 +1,17 @@
+# This workflow demonstrates how to use contexts and variables in GitHub Actions.
+# It retrieves and displays various context values and environment variables.
+# It also shows how to override environment variables at different levels.
+# The workflow is triggered manually using the 'workflow_dispatch' event.
+# The workflow includes two jobs: 'echo-data' and 'echo-data-2'.
+# The 'echo-data' job retrieves and displays context values and environment variables.
+# The 'echo-data-2' job retrieves and displays environment variables.
+# The workflow includes a debug input parameter that can be set to true or false.
+# The debug input parameter is used to control the debug mode of the workflow.
+
 name: Contexts
 run-name: Display Contexts and Variables | Debug - ${{ inputs.debug }}
 
 on: 
-    push:
     workflow_dispatch:
         inputs:
             debug:

--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -1,0 +1,22 @@
+name: Contexts
+
+on: push
+
+jobs:
+    echo-data:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Display Contexts
+              run: |
+                echo "Event Name: ${{ github.event_name }}"
+                echo "Ref: ${{ github.ref }}"
+                echo "SHA: ${{ github.sha }}"
+                echo "Actor: ${{ github.actor }}"
+                echo "Workflow: ${{ github.workflow }}"
+                echo "Run ID: ${{ github.run_id }}"
+                echo "Run Number: ${{ github.run_number }}"
+            - name: Retrieve Variables
+              env:
+                MY_Var: "ExampleValue"
+              run: |
+                echo "Variable value: ${{ env.MY_Var }}"

--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -1,6 +1,14 @@
 name: Contexts
+run-name: Display Contexts and Variables | Debug - ${{ inputs.debug }}
 
-on: push
+on: 
+    push:
+    workflow_dispatch:
+        inputs:
+            debug:
+                type: boolean
+                default: false
+                description: Enable debug mode
 
 jobs:
     echo-data:

--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -43,3 +43,10 @@ jobs:
               run: |
                 echo "MY_WORKFLOW_VAR: ${{ env.MY_WORKFLOW_VAR }}"
                 echo "MY_OVERWRITTEN_VAR: ${{ env.MY_OVERWRITTEN_VAR }}"
+    echo-data-2:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Print environment variables
+              run: |
+                echo "MY_WORKFLOW_VAR: $MY_WORKFLOW_VAR"
+                echo "MY_OVERWRITTEN_VAR: $MY_OVERWRITTEN_VAR"

--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -16,7 +16,5 @@ jobs:
                 echo "Run ID: ${{ github.run_id }}"
                 echo "Run Number: ${{ github.run_number }}"
             - name: Retrieve Variables
-              env:
-                MY_Var: "ExampleValue"
               run: |
-                echo "Variable value: ${{ env.MY_Var }}"
+                echo "Variable value: ${{ vars.MY_VAR }}"

--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -10,9 +10,16 @@ on:
                 default: false
                 description: Enable debug mode
 
+env:
+    MY_WORKFLOW_VAR: "workflow"
+    MY_OVERWRITTEN_VAR: "workflow"
+
 jobs:
     echo-data:
         runs-on: ubuntu-latest
+        env:
+            MY_JOB_VAR: "job"
+            MY_OVERWRITTEN_VAR: "job"
         steps:
             - name: Display Contexts
               run: |
@@ -26,3 +33,13 @@ jobs:
             - name: Retrieve Variables
               run: |
                 echo "Variable value: ${{ vars.MY_VAR }}"
+            - name: Print environment variables
+              env:
+                MY_OVERWRITTEN_VAR: 'step'
+              run: |
+                echo "MY_WORKFLOW_VAR: ${{ env.MY_WORKFLOW_VAR }}"
+                echo "MY_JOB_VAR: ${{ env.MY_OVERWRITTEN_VAR }}"
+            - name: Print environment variables
+              run: |
+                echo "MY_WORKFLOW_VAR: ${{ env.MY_WORKFLOW_VAR }}"
+                echo "MY_OVERWRITTEN_VAR: ${{ env.MY_OVERWRITTEN_VAR }}"

--- a/.github/workflows/execution-flow.yml
+++ b/.github/workflows/execution-flow.yml
@@ -1,0 +1,59 @@
+name: Execution Flow
+
+on: 
+    workflow_dispatch:
+        inputs:
+            pass-unit-tests:
+                type: boolean
+                description: 'Whether unit tests will pass or not'
+                default: true
+
+jobs:
+    lint-build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Lint and build
+              run: |
+                echo "Linting and building the code…"
+                npm run lint
+                npm run format:check
+                npm run tsc:check
+                npm run build
+    unit-tests:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Running unit tests
+              run: echo "Running tests…"
+            - name: Failing tests
+              if: ${{ !inputs.pass-unit-tests }}
+              run: exit 1
+    deploy-nonprod:
+        runs-on: ubuntu-latest
+        needs: 
+            - lint-build
+            - unit-tests
+        steps:
+            - name: Deploying to non-production
+              run: echo "Deploying to non-production environment…"
+    e2e-tests:
+        runs-on: ubuntu-latest
+        needs:
+            - deploy-nonprod
+        steps:
+            - name: Running E2E tests
+              run: echo "Running E2E tests…"
+    load-tests:
+        runs-on: ubuntu-latest
+        needs:
+            - deploy-nonprod
+        steps:
+            - name: Running load tests
+              run: echo "Running load tests…"
+    deploy-prod:
+        runs-on: ubuntu-latest
+        needs:
+            - e2e-tests
+            - load-tests
+        steps:
+            - name: Deploying to production
+              run: echo "Deploying to production environment…"

--- a/.github/workflows/execution-flow.yml
+++ b/.github/workflows/execution-flow.yml
@@ -11,7 +11,7 @@ on:
 jobs:
     lint-build:
         runs-on: ubuntu-latest
-        continue-on-error: true
+        # continue-on-error: true
         steps:
             - name: Lint and build
               run: echo "Linting and building the code…"

--- a/.github/workflows/execution-flow.yml
+++ b/.github/workflows/execution-flow.yml
@@ -11,14 +11,10 @@ on:
 jobs:
     lint-build:
         runs-on: ubuntu-latest
+        continue-on-error: true
         steps:
             - name: Lint and build
-              run: |
-                echo "Linting and building the code…"
-                npm run lint
-                npm run format:check
-                npm run tsc:check
-                npm run build
+              run: echo "Linting and building the code…"
     unit-tests:
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/execution-flow.yml
+++ b/.github/workflows/execution-flow.yml
@@ -1,3 +1,11 @@
+# This workflow demonstrates a complex execution flow with multiple jobs and dependencies.
+# It includes linting, building, unit tests, deployment to non-production, E2E tests,
+# load tests, and deployment to production.
+# The workflow is triggered manually and allows the user to specify whether unit tests
+# will pass or fail.
+# The workflow includes a conditional step that fails the job if the user specifies
+# that unit tests will not pass.
+
 name: Execution Flow
 
 on: 

--- a/.github/workflows/expressions.yml
+++ b/.github/workflows/expressions.yml
@@ -1,0 +1,29 @@
+name: Expressions
+run-name: Expressions | DEBUG - ${{ inputs.debug && 'ON' || 'OFF'}}
+
+on: 
+    push: {}
+    workflow_dispatch:
+        inputs:
+            debug:
+                description: 'Enable debug mode'
+                type: boolean
+                default: false
+
+jobs:
+    echo:
+        runs-on: ubuntu-latest
+        steps:
+            - name: '[debug] Print start-up data'
+              if: inputs.debug
+              run: |
+                echo "Triggered by: ${{ github.event_name }}"
+                echo "Branch: ${{ github.ref }}"
+                echo "Commit SHA: ${{ github.sha }}"
+                echo "Runner OS: ${{ runner.os }}"
+            - name: '[debug] Print when triggered from main'
+              if: inputs.debug && github.ref == 'refs/heads/main'
+              run: echo "I was triggered from the main branch"
+            - name: Gretting
+              run: echo "Hello, world!"
+    

--- a/.github/workflows/expressions.yml
+++ b/.github/workflows/expressions.yml
@@ -8,7 +8,6 @@ name: Expressions
 run-name: Expressions | DEBUG - ${{ inputs.debug && 'ON' || 'OFF'}}
 
 on: 
-    push: {}
     workflow_dispatch:
         inputs:
             debug:

--- a/.github/workflows/expressions.yml
+++ b/.github/workflows/expressions.yml
@@ -1,3 +1,9 @@
+# This workflow demostrates the use of expressions in GitHub Actions.
+# It includes a workflow dispatch input to enable or disable debug mode.
+# It also includes conditional steps that run based on the value of the debug input and the branch from which the workflow is triggered.
+# The workflow is triggered on push events and can be manually triggered using the workflow dispatch event.
+# The workflow includes steps to print start-up data and a greeting message.
+
 name: Expressions
 run-name: Expressions | DEBUG - ${{ inputs.debug && 'ON' || 'OFF'}}
 

--- a/.github/workflows/filters-activity-types-closed.yml
+++ b/.github/workflows/filters-activity-types-closed.yml
@@ -1,3 +1,7 @@
+# This workflow demonstrates the use of event filters and activity types in GitHub Actions.
+# It triggers on pull_request events with specific activity types and branches.
+# It includes a job that runs on the specified events and prints a message.
+
 name: Event Filters and Activity Types
 
 on:

--- a/.github/workflows/filters-activity-types-closed.yml
+++ b/.github/workflows/filters-activity-types-closed.yml
@@ -1,0 +1,14 @@
+name: Event Filters and Activity Types
+
+on:
+    pull_request:
+        types:
+            - closed
+        branches:
+            - main
+
+jobs:
+    echo:
+        runs-on: ubuntu-latest
+        steps:
+            - run: echo "This job runs on pull_request events with type 'closed' for the main branch."

--- a/.github/workflows/filters-activity-types.yml
+++ b/.github/workflows/filters-activity-types.yml
@@ -1,3 +1,7 @@
+# This workflow demonstrates the use of event filters and activity types in GitHub Actions.
+# It triggers on pull_request events with specific activity types and branches.
+# The workflow includes a job that runs on the specified events and prints a message.
+
 name: Event Filters and Activity Types
 
 on:

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -8,6 +8,18 @@ jobs:
     echo1:
         runs-on: ubuntu-latest
         steps:
+            - name: Print PR title
+              run: echo ${{ github.event.pull_request.title }}
+            - name: Print PR labels
+              run: | 
+                cat << EOF 
+                ${{ toJSON(github.event.pull_request.labels) }}
+                EOF
+            - name: Bug step
+              if: ${{ !cancelled() && contains(github.event.pull_request.title, 'fix') }}
+              run: echo "I am a bug fix"
+            - name: Sleep for 20 seconds
+              run: sleep 20
             - name: Failing step
               run: exit 1
             - name: I will be skipped

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -1,8 +1,15 @@
+# This workflow demonstrates the use of functions in GitHub Actions.
+# It includes conditional steps based on the pull request title and labels.
+# It also shows how to use the 'cancelled()' function to check if the workflow was cancelled.
+# The workflow is triggered on pull request events.
+# The workflow includes steps to print the pull request title and labels,
+# as well as steps that will execute or skip based on the success or failure of previous steps.
+# The workflow also includes a step that will execute if the workflow is cancelled.
+
 name: Functions
 
 on: 
     pull_request:
-    workflow_dispatch:
 
 jobs: 
     echo1:
@@ -34,7 +41,3 @@ jobs:
             - name: I will execute when cancelled
               if: ${{ cancelled() }}
               run: echo "I will print if the workflow is cancelled"
-
-
-
-

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -1,0 +1,28 @@
+name: Functions
+
+on: 
+    pull_request:
+    workflow_dispatch:
+
+jobs: 
+    echo1:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Failing step
+              run: exit 1
+            - name: I will be skipped
+              if: ${{ success() }}
+              run: echo "I will print if the previous step was successful"
+            - name: I will be executed
+              if: ${{ failure() }}
+              run: echo "I will print if any previous step failed"
+            - name: I will be execute
+              if: ${{ !cancelled() }}
+              run: echo "I will always print, except when the workflow is cancelled"
+            - name: I will execute when cancelled
+              if: ${{ cancelled() }}
+              run: echo "I will print if the workflow is cancelled"
+
+
+
+

--- a/.github/workflows/inputs.yml
+++ b/.github/workflows/inputs.yml
@@ -1,0 +1,37 @@
+name: Inputs
+
+on:
+    workflow_dispatch:
+        inputs:
+            dry-run:
+                type: boolean
+                description: 'Skep deployment and only print the build output'
+                default: false
+            target:
+                type: environment
+                required: true
+                description: 'Which environment the workflow will be targeting'
+            tag:
+                type: choice
+                options:
+                    - v1
+                    - v2
+                    - v3
+                default: v3
+                description: 'Release from which version to build the image and deploy'
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+              - name: Build
+                run: echo "Building from tag ${{ inputs.tag }}"
+    deploy:
+        runs-on: ubuntu-latest
+        if: ${{ inputs.dry-run }}
+        environment: ${{ inputs.target }}
+        needs: build
+        steps:
+        - name: Deploy
+          run: echo "Deploying to environment ${{ inputs.target }}"
+            

--- a/.github/workflows/inputs.yml
+++ b/.github/workflows/inputs.yml
@@ -1,3 +1,8 @@
+# This workflow demonstrates a complex execution flow with multiple jobs and dependencies.
+# It also includes a manual trigger with inputs for dry-run, target environment, and tag.
+# The workflow is triggered manually and requires the user to specify the target environment
+# and the tag for the build.
+
 name: Inputs
 
 on:

--- a/.github/workflows/matrics.yml
+++ b/.github/workflows/matrics.yml
@@ -25,13 +25,9 @@ jobs:
               uses: actions/setup-node@v3
               with: 
                 node-version: ${{ matrix.node-version }}
-            - name: Fail if experimental
-              if: ${{ matrix.tag == 'experimental' }}
-              run: exit 1
             - name: Perform some tests
               run: |
                echo "Running tests on OS ${{ matrix.os }} and Node.js ${{ matrix.node-version }}"
-               sleep 10
             - name: Upload test results
               run: echo "Uploading test results"
     include-example:
@@ -51,6 +47,12 @@ jobs:
                     - color: yellow
                       shape: rectangle
                     - opacity: 50
+                    - color: purple
+                      shape: circle
+                      size: medium
+                exclude:
+                    - color: purple
+                      shape: circle
         steps:
             - name: Dummy step
               run: echo "Running tests on color ${{ matrix.color }}, shape ${{ matrix.shape }}, and size ${{ matrix.size }} with opacity ${{ matrix.opacity}}"

--- a/.github/workflows/matrics.yml
+++ b/.github/workflows/matrics.yml
@@ -35,7 +35,7 @@ jobs:
             - name: Upload test results
               run: echo "Uploading test results"
     include-example:
-        name: ${{ matrix.color }} - ${{ matrix.shape }} - ${{ matrix.size }}
+        name: ${{ matrix.color }} - ${{ matrix.shape }} - ${{ matrix.size }} - ${{ matrix.opacity }}
         runs-on: ubuntu-latest
         strategy:
             matrix:
@@ -43,8 +43,9 @@ jobs:
                 shape: [circle, square, triangle]
                 size: [small, medium, large]
                 include:
+                    - opacity: 50
                     - color: yellow
                       shape: rectangle
         steps:
             - name: Dummy step
-              run: echo "Running tests on color ${{ matrix.color }}, shape ${{ matrix.shape }}, and size ${{ matrix.size }}"
+              run: echo "Running tests on color ${{ matrix.color }}, shape ${{ matrix.shape }}, and size ${{ matrix.size }} with opacity ${{ matrix.opacity}}"

--- a/.github/workflows/matrics.yml
+++ b/.github/workflows/matrics.yml
@@ -43,12 +43,14 @@ jobs:
                 shape: [circle, square, triangle]
                 size: [small, medium, large]
                 include:
-                    - opacity: 50
+                    - color: yellow
+                    - opacity: 75
                     - color: yellow
                     - shape: circle
                       opacity: 100
                     - color: yellow
                       shape: rectangle
+                    - opacity: 50
         steps:
             - name: Dummy step
               run: echo "Running tests on color ${{ matrix.color }}, shape ${{ matrix.shape }}, and size ${{ matrix.size }} with opacity ${{ matrix.opacity}}"

--- a/.github/workflows/matrics.yml
+++ b/.github/workflows/matrics.yml
@@ -1,0 +1,22 @@
+name: Matrices
+
+on: 
+    workflow_dispatch:
+
+jobs:
+    backwards-compatibility:
+        name: ${{ matrix.os }} - ${{ matrix.node-version }}
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                node-version: [21.x, 22.x, 23.x]
+                os: 
+                    - ubuntu-latest
+                    - windows-latest
+        steps:
+            - name: Setup node
+              uses: actions/setup-node@v3
+              with: ${{ matrix.node-version }}
+            - name: Perform some tests
+              run: echo "Running tests on OS ${{ matrix.os }} and Node.js ${{ matrix.node-version }}"
+

--- a/.github/workflows/matrics.yml
+++ b/.github/workflows/matrics.yml
@@ -34,3 +34,15 @@ jobs:
                sleep 10
             - name: Upload test results
               run: echo "Uploading test results"
+    include-example:
+        name: ${{ matrix.color }} - ${{ matrix.shape }} - ${{ matrix.size }}
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                color: [red, green, blue]
+                shape: [circle, square, triangle]
+                size: [small, medium, large]
+                include:
+                    - color: yellow
+                      shape: rectangle
+                

--- a/.github/workflows/matrics.yml
+++ b/.github/workflows/matrics.yml
@@ -45,4 +45,6 @@ jobs:
                 include:
                     - color: yellow
                       shape: rectangle
-                
+        steps:
+            - name: Dummy step
+              run: echo "Running tests on color ${{ matrix.color }}, shape ${{ matrix.shape }}, and size ${{ matrix.size }}"

--- a/.github/workflows/matrics.yml
+++ b/.github/workflows/matrics.yml
@@ -16,7 +16,8 @@ jobs:
         steps:
             - name: Setup node
               uses: actions/setup-node@v3
-              with: ${{ matrix.node-version }}
+              with: 
+                node-version: ${{ matrix.node-version }}
             - name: Perform some tests
               run: echo "Running tests on OS ${{ matrix.os }} and Node.js ${{ matrix.node-version }}"
 

--- a/.github/workflows/matrics.yml
+++ b/.github/workflows/matrics.yml
@@ -8,16 +8,29 @@ jobs:
         name: ${{ matrix.os }} - ${{ matrix.node-version }}
         runs-on: ${{ matrix.os }}
         strategy:
+            fail-fast: false
             matrix:
                 node-version: [21.x, 22.x, 23.x]
                 os: 
                     - ubuntu-latest
                     - windows-latest
+                include:
+                  - os: ubuntu-latest
+                    node-version: 21.x
+                  - os: ubuntu-latest
+                    node-version: 23.x
+                    tag: experimental
         steps:
             - name: Setup node
               uses: actions/setup-node@v3
               with: 
                 node-version: ${{ matrix.node-version }}
+            - name: Fail if experimental
+              if: ${{ matrix.tag == 'experimental' }}
+              run: exit 1
             - name: Perform some tests
-              run: echo "Running tests on OS ${{ matrix.os }} and Node.js ${{ matrix.node-version }}"
-
+              run: |
+               echo "Running tests on OS ${{ matrix.os }} and Node.js ${{ matrix.node-version }}"
+               sleep 10
+            - name: Upload test results
+              run: echo "Uploading test results"

--- a/.github/workflows/matrics.yml
+++ b/.github/workflows/matrics.yml
@@ -45,6 +45,9 @@ jobs:
                 include:
                     - opacity: 50
                     - color: yellow
+                    - shape: circle
+                      opacity: 100
+                    - color: yellow
                       shape: rectangle
         steps:
             - name: Dummy step

--- a/.github/workflows/matrics.yml
+++ b/.github/workflows/matrics.yml
@@ -8,7 +8,7 @@ jobs:
         name: ${{ matrix.os }} - ${{ matrix.node-version }}
         runs-on: ${{ matrix.os }}
         strategy:
-            fail-fast: false
+            fail-fast: true
             matrix:
                 node-version: [21.x, 22.x, 23.x]
                 os: 

--- a/.github/workflows/outputs.yml
+++ b/.github/workflows/outputs.yml
@@ -15,12 +15,22 @@ jobs:
         runs-on: ubuntu-latest
         outputs:
             build-status: ${{ steps.build.outputs.status }}
+            output1: ${{ steps.build.outputs.output1 }}
         steps:
             - name: Print GITHUB_OUTPUT path
               run: echo "$GITHUB_OUTPUT"
             - name: Build
               id: build
-              run: echo "stauts=${{ inputs.build-status }}" >> $GITHUB_OUTPUT
+              run: |
+                echo "$GITHUB_OUTPUT"
+                echo "stauts=${{ inputs.build-status }}" >> "$GITHUB_OUTPUT"
+                echo "output1=value1" >> "$GITHUB_OUTPUT"
+                echo "output2=value2" >> "$GITHUB_OUTPUT"
+                cat "$GITHUB_OUTPUT"
+            - name: Step with mistake
+              run: |
+                echo "mistake=true" > "$GITHUB_OUTPUT"
+                cat "$GITHUB_OUTPUT"
     deploy:
         runs-on: ubuntu-latest
         needs: build
@@ -28,3 +38,6 @@ jobs:
         steps:
             - name: Deploy
               run: echo "Deploying…"
+            - name: Print Outputs
+              run: |
+                echo "Output 1: ${{ needs.build.outputs.output1 }}"

--- a/.github/workflows/outputs.yml
+++ b/.github/workflows/outputs.yml
@@ -1,0 +1,30 @@
+name: Outputs
+
+on:
+    workflow_dispatch:
+        inputs:
+            build-status:
+                type: choice
+                options:
+                    - success
+                    - failure
+                default: success
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        outputs:
+            build-status: ${{ steps.build.outputs.status }}
+        steps:
+            - name: Print GITHUB_OUTPUT path
+              run: echo "$GITHUB_OUTPUT"
+            - name: Build
+              id: build
+              run: echo "stauts=${{ inputs.build-status }}" >> $GITHUB_OUTPUT
+    deploy:
+        runs-on: ubuntu-latest
+        needs: build
+        if: ${{ needs.build.outputs.build-status == 'success' }}
+        steps:
+            - name: Deploy
+              run: echo "Deploying…"

--- a/.github/workflows/outputs.yml
+++ b/.github/workflows/outputs.yml
@@ -1,3 +1,10 @@
+# This workflow demonstrates a complex execution flow with multiple jobs and dependencies.
+# It includes a build job that generates outputs and a deploy job that uses those outputs.
+# The deploy job is conditional based on the build job's output status.
+# The build job also includes a step that intentionally makes a mistake to show how it affects the workflow.
+# The workflow is triggered manually with a choice input for the build status.
+# The build job outputs are printed in the deploy job.
+
 name: Outputs
 
 on:

--- a/.github/workflows/variables.yml
+++ b/.github/workflows/variables.yml
@@ -1,3 +1,14 @@
+# This workflow demonstrates the use of environment variables in GitHub Actions.
+# It includes examples of workflow, job, and step-level variables,
+# as well as how to overwrite variables at different levels.
+# It also shows how to use variables in different jobs and how to handle undefined variables.
+# The workflow is triggered on push and manually via workflow_dispatch.
+# The workflow includes three jobs:
+    # echo: Prints environment variables at the step level and overwrites a job variables.
+    # echo2: Prints organization and repository variables.
+    # echo-prod: Prints organization, repository, and environment variables.
+# The workflow also includes a job that prints an undefined variable with a default value.
+
 name: Variables
 
 on:

--- a/.github/workflows/variables.yml
+++ b/.github/workflows/variables.yml
@@ -18,7 +18,7 @@ on:
 env:
     WORKFLOW_VAR: 'I am a workflow variable'
     OVERWRITTEN: 'I will be overwritten'
-    UNDEFINED_VAR_WITH_DEFAULT: 'default value'
+    UNDEFINED_VAR_WITH_DEFAULT: ${{ vars.UNDEFINED_VAR || 'default values'}}
 
 jobs:
     echo:
@@ -44,28 +44,28 @@ jobs:
                 echo "Step environment variables: ${{ env.OVERWRITTEN }}"
     echo2:
         runs-on: ubuntu-latest
-        env:
-            REPOSITORY_VAR: 'Default repository variable value'
+        #env:
+            #REPOSITORY_VAR: 'Default repository variable value'
         steps:
             - name: Print variables
-              env:
-                ORG_VAR: 'Default organization variable value'
+            #  env:
+             #   ORG_VAR: 'Default organization variable value'
               run: | 
                 echo "Organization variable: ${{ env.ORG_VAR }}"
-                echo "Organization overwritten variable: Variable OVERWRITTEN_VAR is not defined"
+                echo "Organization overwritten variable: ${{ vars.OVERWRITTEN_VAR }}"
                 echo "Repository variable: ${{ env.REPOSITORY_VAR }}"
     echo-prod:
         runs-on: ubuntu-latest
-        env:
-            ORG_VAR: 'Default organization variable value'
-            REPOSITORY_VAR: 'Default repository variable value'
-            TARGET_VAR: 'Defined target variable value'
-        # environment: prod
+        #env:
+          #  ORG_VAR: 'Default organization variable value'
+           # REPOSITORY_VAR: 'Default repository variable value'
+            #TARGET_VAR: 'Defined target variable value'
+        environment: prod
         steps:
             - name: Print prod variables
               run: |
                 echo "Organization variable: ${{ env.ORG_VAR }}"
-                echo "Organization overwritten variable: Variable OVERWRITTEN_VAR is not defined"
+                echo "Organization overwritten variable: ${{ vars.OVERWRITTEN_VAR }}"
                 echo "Repository variable: ${{ env.REPOSITORY_VAR }}"
                 echo "Environment variable: ${{ env.TARGET_VAR }}"
     echo-undifined:

--- a/.github/workflows/variables.yml
+++ b/.github/workflows/variables.yml
@@ -1,0 +1,65 @@
+name: Variables
+
+on:
+    push:
+    workflow_dispatch:
+
+env:
+    WORKFLOW_VAR: 'I am a workflow variable'
+    OVERWRITTEN: 'I will be overwritten'
+    UNDEFINED_VAR_WITH_DEFAULT: 'default value'
+
+jobs:
+    echo:
+        runs-on: ubuntu-latest
+        env:
+            JOB_VAR: 'I am a job variable'
+            OVERWRITTEN: 'I have been overwritten at the job level'
+        steps:
+            - name: Print environment variables
+              env:
+                STEP_VAR: 'I am a step environment variable'
+                step_var2: 'I am another step environment variable'
+              run: |
+                echo "Step environment variables: ${{ env.STEP_VAR }}"
+                echo "Step environment variables 2: $step_var2"
+                echo "Job environment variables: ${{ env.JOB_VAR }}"
+                echo "Workflow environment variables: ${{ env.WORKFLOW_VAR }}"
+                echo "Overwritten environment variables: ${{ env.OVERWRITTEN }}"
+            - name: Overwrite job variable
+              env:
+                OVERWRITTEN: 'I have been overwritten at the step level'
+              run: |
+                echo "Step environment variables: ${{ env.OVERWRITTEN }}"
+    echo2:
+        runs-on: ubuntu-latest
+        env:
+            REPOSITORY_VAR: 'Default repository variable value'
+        steps:
+            - name: Print variables
+              env:
+                ORG_VAR: 'Default organization variable value'
+              run: | 
+                echo "Organization variable: ${{ env.ORG_VAR }}"
+                echo "Organization overwritten variable: Variable OVERWRITTEN_VAR is not defined"
+                echo "Repository variable: ${{ env.REPOSITORY_VAR }}"
+    echo-prod:
+        runs-on: ubuntu-latest
+        env:
+            ORG_VAR: 'Default organization variable value'
+            REPOSITORY_VAR: 'Default repository variable value'
+            TARGET_VAR: 'Defined target variable value'
+        # environment: prod
+        steps:
+            - name: Print prod variables
+              run: |
+                echo "Organization variable: ${{ env.ORG_VAR }}"
+                echo "Organization overwritten variable: Variable OVERWRITTEN_VAR is not defined"
+                echo "Repository variable: ${{ env.REPOSITORY_VAR }}"
+                echo "Environment variable: ${{ env.TARGET_VAR }}"
+    echo-undifined:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Print undefined variable
+              run: |
+                echo "Orgainization variable: ${{ env.UNDEFINED_VAR_WITH_DEFAULT }}"

--- a/.github/workflows/variables.yml
+++ b/.github/workflows/variables.yml
@@ -18,7 +18,7 @@ on:
 env:
     WORKFLOW_VAR: 'I am a workflow variable'
     OVERWRITTEN: 'I will be overwritten'
-    UNDEFINED_VAR_WITH_DEFAULT: ${{ vars.UNDEFINED_VAR || 'default values'}}
+    UNDEFINED_VAR_WITH_DEFAULT: 'default values'
 
 jobs:
     echo:
@@ -44,22 +44,22 @@ jobs:
                 echo "Step environment variables: ${{ env.OVERWRITTEN }}"
     echo2:
         runs-on: ubuntu-latest
-        #env:
-            #REPOSITORY_VAR: 'Default repository variable value'
+        env:
+            ORG_VAR: 'Default organization variable value'
+            REPOSITORY_VAR: 'Default repository variable value'
+            OVERWRITTEN_VAR: 'Default overwritten variable value'
         steps:
             - name: Print variables
-            #  env:
-             #   ORG_VAR: 'Default organization variable value'
               run: | 
                 echo "Organization variable: ${{ env.ORG_VAR }}"
-                echo "Organization overwritten variable: ${{ vars.OVERWRITTEN_VAR }}"
+                echo "Organization overwritten variable: ${{ env.OVERWRITTEN_VAR }}"
                 echo "Repository variable: ${{ env.REPOSITORY_VAR }}"
     echo-prod:
         runs-on: ubuntu-latest
-        #env:
-          #  ORG_VAR: 'Default organization variable value'
-           # REPOSITORY_VAR: 'Default repository variable value'
-            #TARGET_VAR: 'Defined target variable value'
+        env:
+            ORG_VAR: 'Default organization variable value'
+            REPOSITORY_VAR: 'Default repository variable value'
+            TARGET_VAR: 'Defined target variable value'
         environment: prod
         steps:
             - name: Print prod variables


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to handle specific pull request events. The workflow is triggered when a pull request of type `closed` targets the `main` branch.

New GitHub Actions workflow:

* [`.github/workflows/filters-activity-types-closed.yml`](diffhunk://#diff-3faadd5ee399a04e30b6cd6bbcd8e251a5dfbb56cab814e1fa3c661f0e01e21bR1-R14): Introduced a new workflow named "Event Filters and Activity Types." It listens for `pull_request` events with the `closed` type on the `main` branch and includes a job that echoes a message.